### PR TITLE
A more sensible activation condition.

### DIFF
--- a/src/main/java/io/github/mireole/mgtceua/common/covers/MEMachineController.java
+++ b/src/main/java/io/github/mireole/mgtceua/common/covers/MEMachineController.java
@@ -239,7 +239,7 @@ public class MEMachineController extends AbstractMeMachineController implements 
         IControllable controllable = this.getCoverableView().getCapability(GregtechTileCapabilities.CAPABILITY_CONTROLLABLE, this.getAttachedSide());
         if (controllable == null) return;
 
-        this.enabled = !this.mode.evaluate(this.amount, this.networkAmount);
+        this.enabled = this.mode.evaluate(this.amount, this.networkAmount);
         controllable.setWorkingEnabled(this.enabled);
         this.writeCustomData(GregtechDataCodes.UPDATE_COVER_MODE, buf -> buf.writeBoolean(this.enabled));
     }


### PR DESCRIPTION
Right now having more than the set amount of items and setting the cover to "more than" will disable the machine. It makes more sense to me that when the condition is satisfied, the machine is on

> Redstone on, machine on!